### PR TITLE
Validates API Key and API Secret when communicating with btcbox's API that requires authentications.

### DIFF
--- a/btcbox.go
+++ b/btcbox.go
@@ -2,6 +2,7 @@ package btcbox
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"time"
 	//simplejson "github.com/bitly/go-simplejson"
@@ -43,10 +44,18 @@ func (b *BTCBox) GetBalance() (balance Balance, r []byte, err error) {
 	if err != nil {
 		return
 	}
+
 	if err = json.Unmarshal(r, &balance); err != nil {
 		return
 	}
-	return
+
+	if len(balance.Code) == 0 {
+		balance.Result = true
+		balance.Code = "200"
+		return
+	}
+
+	return balance, nil, errors.New("Authentication failed")
 }
 
 // GetTicker ..

--- a/btcbox_test.go
+++ b/btcbox_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestGetTicker(t *testing.T) {
-
 	token := os.Getenv("BTCBOX_KEY")
 	secret := os.Getenv("BTCBOX_SECRET")
 	api := New(token, secret)
@@ -34,8 +33,10 @@ func TestGetBalance(t *testing.T) {
 	api := New(token, secret)
 
 	balance, body, err := api.GetBalance()
-	log.Printf("err:%v", err)
-	require.NoError(t, err, nil)
+	if err != nil {
+		t.Fatal(err)
+		require.NoError(t, err, nil)
+	}
 	log.Printf("body:%s", string(body))
 	log.Printf("balance:%v", balance)
 	log.Printf("balance.BTCBalance:%v", balance.BTCBalance)

--- a/type.go
+++ b/type.go
@@ -18,6 +18,8 @@ type Ticker struct {
 // "doge_balance":0,"doge_lock":0,"eth_balance":1.998236,"eth_lock":0,
 //"jpy_balance":1218.298,"jpy_lock":0}
 type Balance struct {
+	Result      bool            `json:"result"`
+	Code        string          `json:"code"`
 	UID         int64           `json:"uid"`
 	Nameauth    int64           `json:"nameauth"`
 	Moflag      int64           `json:"moflag"`


### PR DESCRIPTION
Validates `API Key` and `API Secret` when communicating with btcbox's API that requires authentications.

When authentication fails, `response.Body` returns `Balance.Result = false` and `Balance.Code = "100"`. However, then authentication is successful, `response.Body` returns `Balance.Result = true` and `Balance.Code = "200"` alongside with other coin details.